### PR TITLE
Prevent exceptions on UnionTypes

### DIFF
--- a/src/Rule/CurrencyAvailableWithinToCurrenciesContainsRector.php
+++ b/src/Rule/CurrencyAvailableWithinToCurrenciesContainsRector.php
@@ -7,7 +7,8 @@ namespace Codito\Rector\Money\Rule;
 use Money\Currency;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -49,10 +50,10 @@ final class CurrencyAvailableWithinToCurrenciesContainsRector extends AbstractRe
 
     private function shouldSkip(MethodCall $node): bool
     {
-        /** @var ObjectType $executedOn */
         $executedOn = $this->nodeTypeResolver->getNativeType($node->var);
 
-        return $executedOn->getClassName() !== Currency::class
+        return !$executedOn instanceof TypeWithClassName
+            || $executedOn->getClassName() !== Currency::class
             || $this->nodeNameResolver->getName($node->name) !== 'isAvailableWithin';
     }
 }

--- a/src/Rule/CurrencyAvailableWithinToCurrenciesContainsRector.php
+++ b/src/Rule/CurrencyAvailableWithinToCurrenciesContainsRector.php
@@ -7,7 +7,6 @@ namespace Codito\Rector\Money\Rule;
 use Money\Currency;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;

--- a/src/Rule/MultiplyAndDivideByStringRector.php
+++ b/src/Rule/MultiplyAndDivideByStringRector.php
@@ -17,7 +17,8 @@ use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\FloatType;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\PhpParser\AstResolver;
 use Rector\Core\Rector\AbstractRector;
@@ -31,7 +32,7 @@ final class MultiplyAndDivideByStringRector extends AbstractRector implements Al
 {
     public const PRECISION = 'precision';
 
-    private int $precision;
+    private int $precision = 5;
 
     private AstResolver $astResolver;
 
@@ -123,10 +124,10 @@ final class MultiplyAndDivideByStringRector extends AbstractRector implements Al
 
     private function shouldSkip(MethodCall $node): bool
     {
-        /** @var ObjectType $executedOn */
         $executedOn = $this->nodeTypeResolver->getNativeType($node->var);
 
-        return $executedOn->getClassName() !== Money::class
+        return !$executedOn instanceof TypeWithClassName
+            || $executedOn->getClassName() !== Money::class
             || !$node->name instanceof Identifier
             || !in_array($node->name->toLowerString(), ['divide', 'multiply'], true);
     }

--- a/src/Rule/MultiplyAndDivideByStringRector.php
+++ b/src/Rule/MultiplyAndDivideByStringRector.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Scalar\DNumber;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\FloatType;
-use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use Rector\Core\Contract\Rector\AllowEmptyConfigurableRectorInterface;
 use Rector\Core\PhpParser\AstResolver;
@@ -32,7 +31,7 @@ final class MultiplyAndDivideByStringRector extends AbstractRector implements Al
 {
     public const PRECISION = 'precision';
 
-    private int $precision = 5;
+    private int $precision;
 
     private AstResolver $astResolver;
 

--- a/tests/Rule/CurrencyAvailableWithinToCurrenciesContainsRector/Fixture/skip_union_types.php.inc
+++ b/tests/Rule/CurrencyAvailableWithinToCurrenciesContainsRector/Fixture/skip_union_types.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rector\Money\Tests\Rule\CurrencyAvailableWithinToCurrenciesContainsRector\Fixture;
+
+use Money\Currencies\CurrencyList;
+use Money\Currency;
+use function mt_rand;
+
+/**
+ * @return Currency|array|false
+ */
+function willReturnCurrencyOrSomethingDifferent() {
+    $random = mt_rand(0, 10);
+    if ($random % 3 === 0) {
+        return new Currency('EUR');
+    }
+    if ($random === 5) {
+        return ['some' => 'other', 'data'];
+    }
+    return false;
+}
+
+$collection = new CurrencyList([new Currency('PLN')]);
+willReturnCurrencyOrSomethingDifferent()
+    ->isAvailableWithin($collection);
+
+?>
+

--- a/tests/Rule/MultiplyAndDivideByStringRector/Fixture/skip_union_types.php.inc
+++ b/tests/Rule/MultiplyAndDivideByStringRector/Fixture/skip_union_types.php.inc
@@ -6,11 +6,6 @@ use Money\Currency;
 use Money\Money;
 use function mt_rand;
 
-function returnInt(): int
-{
-    return 1;
-}
-
 class UnionReturning
 {
     /**
@@ -40,6 +35,10 @@ class UnionReturning
 $unionReturning = new UnionReturning();
 $unionReturning->bar()->divide(1);
 $unionReturning->bar()->multiply(2);
+$unionReturning->bar()->divide(1.1);
+$unionReturning->bar()->multiply(2.5);
 
 UnionReturning::foo()->divide(3);
 UnionReturning::foo()->multiply(4);
+UnionReturning::foo()->divide(3.5);
+UnionReturning::foo()->multiply(4.6);

--- a/tests/Rule/MultiplyAndDivideByStringRector/Fixture/skip_union_types.php.inc
+++ b/tests/Rule/MultiplyAndDivideByStringRector/Fixture/skip_union_types.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Rector\Money\Tests\Rule\MultiplyAndDivideByStringRector\Fixture;
+
+use Money\Currency;
+use Money\Money;
+use function mt_rand;
+
+function returnInt(): int
+{
+    return 1;
+}
+
+class UnionReturning
+{
+    /**
+     * @return Money|array|false
+     */
+    public static function foo()
+    {
+        $random = mt_rand(0, 10);
+        if ($random % 3 === 0) {
+            return new Money($random, new Currency('EUR'));
+        }
+        if ($random === 5) {
+            return ['some' => 'other', 'data'];
+        }
+        return false;
+    }
+
+    /**
+     * @return Money|array|false
+     */
+    public function bar()
+    {
+        return self::foo();
+    }
+}
+
+$unionReturning = new UnionReturning();
+$unionReturning->bar()->divide(1);
+$unionReturning->bar()->multiply(2);
+
+UnionReturning::foo()->divide(3);
+UnionReturning::foo()->multiply(4);


### PR DESCRIPTION
If you have a codebase with functions that return UnionTypes this rector sadly will fail with a fatal error
```
Fatal error: Uncaught Error: Call to undefined method PHPStan\Type\UnionType::getClassName() in vendor/codito/rector-money/src/Rule/CurrencyAvailableWithinToCurrenciesContainsRector.php:55

 Fatal error: Call to undefined method PHPStan\Type\UnionType::getClassName() in vendor/codito/rector-money/src/Rule/MultiplyAndDivideByStringRector.php:129
```

This PR won't do magic like checking each type in its union but at least allow the rector to work as intended on simpler code without variable return types.